### PR TITLE
Add wallet sync server to Prometheus

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -50,3 +50,11 @@ scrape_configs:
   static_configs:
   - targets:
     - host.docker.internal:2114
+
+- job_name: wallet_sync
+  metrics_path: /metrics
+  scheme: https
+  scrape_interval: 60s
+  static_configs:
+  - targets:
+    - dev.lbry.id:8091


### PR DESCRIPTION
Spun it up myself and I (finally) got Grafana to show evidence that it can see this data. So far the only metric from wallet sync is `wallet_sync_requests_count`.